### PR TITLE
Add typed configuration service

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,8 +13,8 @@ import { IdentityModule } from '@modules/identity/identity.module'
 import { MikroOrmModule } from '@mikro-orm/nestjs'
 import { EstablishmentModule } from '@modules/establishment/establishment.module'
 import { DataModule } from '@modules/data/data.module'
-import { AppConfigServiceModule } from '@modules/app-config/app-config.module'
-import { AppConfigService } from '@modules/app-config/app-config.service'
+import { AppConfigModule } from '@modules/app-config/app-config.module'
+import { AppConfig } from '@modules/app-config/app-config.service'
 
 const helperModules = [
   HttpModule,
@@ -22,8 +22,8 @@ const helperModules = [
   ScheduleModule.forRoot(),
   MikroOrmModule.forRoot(),
   LoggerModule.forRootAsync({
-    inject: [AppConfigService],
-    useFactory: async (config: AppConfigService) => {
+    inject: [AppConfig],
+    useFactory: async (config: AppConfig) => {
       return {
         pinoHttp: {
           level: config.isProduction ? 'info' : 'debug',
@@ -55,7 +55,7 @@ const helperModules = [
       DOWNLOAD_PATH: Joi.string().required()
     })
   }),
-  AppConfigServiceModule,
+  AppConfigModule,
   CacheModule.registerAsync({
     useFactory: async () => ({
       store: (await redisStore({ url: 'redis://redis:6379', ttl: 5 })) as unknown as CacheStore

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { IdentityModule } from '@modules/identity/identity.module'
 import { MikroOrmModule } from '@mikro-orm/nestjs'
 import { EstablishmentModule } from '@modules/establishment/establishment.module'
 import { DataModule } from '@modules/data/data.module'
+import { AppConfigModule } from '@modules/app-config/app-config.module'
 
 const helperModules = [
   HttpModule,
@@ -57,6 +58,7 @@ const helperModules = [
       DOWNLOAD_PATH: Joi.string().required()
     })
   }),
+  AppConfigModule,
   CacheModule.registerAsync({
     useFactory: async () => ({
       store: (await redisStore({ url: 'redis://redis:6379', ttl: 5 })) as unknown as CacheStore

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -42,16 +42,16 @@ const helperModules = [
   ConfigModule.forRoot({
     cache: true,
     validationSchema: Joi.object({
-      DB_HOST: Joi.string().required(),
-      DB_PORT: Joi.number().required(),
+      DB_HOST: Joi.string().hostname().required(),
+      DB_PORT: Joi.number().port().required(),
       DB_USERNAME: Joi.string().required(),
       DB_PASSWORD: Joi.string().required(),
       DB_DATABASE: Joi.string().required(),
-      PORT: Joi.number().required(),
-      HOST: Joi.string().required(),
-      MODE: Joi.string().required(),
+      PORT: Joi.number().port().required(),
+      HOST: Joi.string().hostname().required(),
+      MODE: Joi.string().valid('dev', 'production').required(),
       JWT_SECRET: Joi.string().required(),
-      CNPJ_MANTENEDORA: Joi.string().required(),
+      CNPJ_MANTENEDORA: Joi.string().length(14).required(),
       DOWNLOAD_PATH: Joi.string().required()
     })
   }),

--- a/src/modules/app-config/app-config.module.ts
+++ b/src/modules/app-config/app-config.module.ts
@@ -1,11 +1,11 @@
 import { Global, Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
-import { AppConfigService } from './app-config.service'
+import { AppConfig } from './app-config.service'
 
 @Global()
 @Module({
-  providers: [AppConfigService],
+  providers: [AppConfig],
   imports: [ConfigModule],
-  exports: [AppConfigService]
+  exports: [AppConfig]
 })
-export class AppConfigServiceModule {}
+export class AppConfigModule {}

--- a/src/modules/app-config/app-config.module.ts
+++ b/src/modules/app-config/app-config.module.ts
@@ -1,10 +1,11 @@
-import { Module } from '@nestjs/common'
+import { Global, Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { AppConfigService } from './app-config.service'
 
+@Global()
 @Module({
   providers: [AppConfigService],
   imports: [ConfigModule],
   exports: [AppConfigService]
 })
-export class AppConfigModule {}
+export class AppConfigServiceModule {}

--- a/src/modules/app-config/app-config.module.ts
+++ b/src/modules/app-config/app-config.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
+import { AppConfigService } from './app-config.service'
+
+@Module({
+  providers: [AppConfigService],
+  imports: [ConfigModule],
+  exports: [AppConfigService]
+})
+export class AppConfigModule {}

--- a/src/modules/app-config/app-config.service.spec.ts
+++ b/src/modules/app-config/app-config.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { AppConfigService } from './app-config.service'
+
+describe('AppConfigService', () => {
+  let service: AppConfigService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AppConfigService]
+    }).compile()
+
+    service = module.get<AppConfigService>(AppConfigService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/src/modules/app-config/app-config.service.spec.ts
+++ b/src/modules/app-config/app-config.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@automock/jest'
 import { ConfigService } from '@nestjs/config'
-import { AppConfigService } from './app-config.service'
+import { AppConfig } from './app-config.service'
 
-describe('AppConfigService', () => {
-  let config: AppConfigService
+describe('AppConfig', () => {
+  let config: AppConfig
   let globalConfig: ConfigService
 
   beforeEach(async () => {
-    const { unit, unitRef } = TestBed.create(AppConfigService)
+    const { unit, unitRef } = TestBed.create(AppConfig)
       .mock(ConfigService)
       .using({
         get: jest.fn().mockImplementation((key: string) => {

--- a/src/modules/app-config/app-config.service.ts
+++ b/src/modules/app-config/app-config.service.ts
@@ -9,7 +9,7 @@ import {
 } from './types'
 
 @Injectable()
-export class AppConfigService {
+export class AppConfig {
   constructor(private readonly configService: ConfigService) {}
 
   get app(): ApplicationConfig {

--- a/src/modules/app-config/app-config.service.ts
+++ b/src/modules/app-config/app-config.service.ts
@@ -1,16 +1,22 @@
 import { Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
-import { AppConfig, AppMode, DatabaseConfig, SecurityConfig, SynchronizationConfig } from './types'
+import {
+  ApplicationConfig,
+  ApplicationMode,
+  DatabaseConfig,
+  SecurityConfig,
+  SynchronizationConfig
+} from './types'
 
 @Injectable()
 export class AppConfigService {
-  constructor(private configService: ConfigService) {}
+  constructor(private readonly configService: ConfigService) {}
 
-  get app(): AppConfig {
+  get app(): ApplicationConfig {
     return {
       host: this.configService.get<string>('HOST'),
       port: this.configService.get<number>('PORT'),
-      mode: this.configService.get<AppMode>('MODE')
+      mode: this.configService.get<ApplicationMode>('MODE')
     }
   }
 
@@ -35,5 +41,9 @@ export class AppConfigService {
       maintainerCnpj: this.configService.get<string>('MAINTAINER_CNPJ'),
       downloadPath: this.configService.get<string>('DOWNLOAD_PATH')
     }
+  }
+
+  get isProduction(): boolean {
+    return this.app.mode === 'production'
   }
 }

--- a/src/modules/app-config/app-config.service.ts
+++ b/src/modules/app-config/app-config.service.ts
@@ -1,4 +1,39 @@
 import { Injectable } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { AppConfig, AppMode, DatabaseConfig, SecurityConfig, SynchronizationConfig } from './types'
 
 @Injectable()
-export class AppConfigService {}
+export class AppConfigService {
+  constructor(private configService: ConfigService) {}
+
+  get app(): AppConfig {
+    return {
+      host: this.configService.get<string>('HOST'),
+      port: this.configService.get<number>('PORT'),
+      mode: this.configService.get<AppMode>('MODE')
+    }
+  }
+
+  get db(): DatabaseConfig {
+    return {
+      host: this.configService.get<string>('DB_HOST'),
+      port: this.configService.get<number>('DB_PORT'),
+      username: this.configService.get<string>('DB_USERNAME'),
+      password: this.configService.get<string>('DB_PASSWORD'),
+      name: this.configService.get<string>('DB_NAME')
+    }
+  }
+
+  get security(): SecurityConfig {
+    return {
+      jwtSecret: this.configService.get<string>('JWT_SECRET')
+    }
+  }
+
+  get synchronization(): SynchronizationConfig {
+    return {
+      maintainerCnpj: this.configService.get<string>('MAINTAINER_CNPJ'),
+      downloadPath: this.configService.get<string>('DOWNLOAD_PATH')
+    }
+  }
+}

--- a/src/modules/app-config/app-config.service.ts
+++ b/src/modules/app-config/app-config.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class AppConfigService {}

--- a/src/modules/app-config/types.ts
+++ b/src/modules/app-config/types.ts
@@ -6,11 +6,11 @@ export type DatabaseConfig = {
   name: string
 }
 
-export type AppMode = 'dev' | 'production'
-export type AppConfig = {
+export type ApplicationMode = 'dev' | 'production'
+export type ApplicationConfig = {
   host: string
   port: number
-  mode: AppMode
+  mode: ApplicationMode
 }
 
 export type SecurityConfig = {

--- a/src/modules/app-config/types.ts
+++ b/src/modules/app-config/types.ts
@@ -1,0 +1,23 @@
+export type DatabaseConfig = {
+  host: string
+  port: number
+  username: string
+  password: string
+  name: string
+}
+
+export type AppMode = 'dev' | 'production'
+export type AppConfig = {
+  host: string
+  port: number
+  mode: AppMode
+}
+
+export type SecurityConfig = {
+  jwtSecret: string
+}
+
+export type SynchronizationConfig = {
+  maintainerCnpj: string
+  downloadPath: string
+}

--- a/src/modules/establishment/services/synchronization.service.ts
+++ b/src/modules/establishment/services/synchronization.service.ts
@@ -1,11 +1,11 @@
 import { DataDownloader } from '@modules/data/data-downloader.service'
 import { FileIOService } from '@modules/data/file-io.service'
 import { Injectable, Logger } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import { plainToInstance } from 'class-transformer'
 import { Establishment } from '../entities/establishment.entity'
 import { EstablishmentService } from './establishment.service'
 import path from 'path'
+import { AppConfigService } from '@modules/app-config/app-config.service'
 
 @Injectable()
 export class SynchronizationService {
@@ -15,11 +15,11 @@ export class SynchronizationService {
     private readonly establishmentService: EstablishmentService,
     private readonly dataDownloader: DataDownloader,
     private readonly fileIOService: FileIOService,
-    private readonly configService: ConfigService
+    private readonly config: AppConfigService
   ) {}
 
   async synchronize(year: number, month: number) {
-    const directory = path.join(process.cwd(), this.configService.get('DOWNLOAD_PATH'))
+    const directory = path.join(process.cwd(), this.config.synchronization.downloadPath)
 
     this.logger.log('Downloading datasus database...')
 
@@ -55,7 +55,7 @@ export class SynchronizationService {
         const csv = line.split(';')
         const cnpj: string = JSON.parse(csv[2])
 
-        if (cnpj !== this.configService.get('CNPJ_MANTENEDORA')) {
+        if (cnpj !== this.config.synchronization.maintainerCnpj) {
           return null
         }
 

--- a/src/modules/establishment/services/synchronization.service.ts
+++ b/src/modules/establishment/services/synchronization.service.ts
@@ -5,7 +5,7 @@ import { plainToInstance } from 'class-transformer'
 import { Establishment } from '../entities/establishment.entity'
 import { EstablishmentService } from './establishment.service'
 import path from 'path'
-import { AppConfigService } from '@modules/app-config/app-config.service'
+import { AppConfig } from '@modules/app-config/app-config.service'
 
 @Injectable()
 export class SynchronizationService {
@@ -15,7 +15,7 @@ export class SynchronizationService {
     private readonly establishmentService: EstablishmentService,
     private readonly dataDownloader: DataDownloader,
     private readonly fileIOService: FileIOService,
-    private readonly config: AppConfigService
+    private readonly config: AppConfig
   ) {}
 
   async synchronize(year: number, month: number) {

--- a/src/modules/identity/auth/auth.module.ts
+++ b/src/modules/identity/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { AppConfigService } from '@modules/app-config/app-config.service'
+import { AppConfig } from '@modules/app-config/app-config.service'
 import { Module } from '@nestjs/common'
 import { JwtModule } from '@nestjs/jwt'
 import { PassportModule } from '@nestjs/passport'
@@ -17,8 +17,8 @@ import { LocalStrategy } from './strategies/local.strategy'
     UserModule,
     PassportModule,
     JwtModule.registerAsync({
-      inject: [AppConfigService],
-      useFactory: async (config: AppConfigService) => ({
+      inject: [AppConfig],
+      useFactory: async (config: AppConfig) => ({
         secret: config.security.jwtSecret,
         signOptions: {
           expiresIn: '24h'

--- a/src/modules/identity/auth/auth.module.ts
+++ b/src/modules/identity/auth/auth.module.ts
@@ -1,5 +1,5 @@
+import { AppConfigService } from '@modules/app-config/app-config.service'
 import { Module } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import { JwtModule } from '@nestjs/jwt'
 import { PassportModule } from '@nestjs/passport'
 import { UserModule } from '../user/user.module'
@@ -17,9 +17,9 @@ import { LocalStrategy } from './strategies/local.strategy'
     UserModule,
     PassportModule,
     JwtModule.registerAsync({
-      inject: [ConfigService],
-      useFactory: async (configService: ConfigService) => ({
-        secret: configService.get('JWT_SECRET'),
+      inject: [AppConfigService],
+      useFactory: async (config: AppConfigService) => ({
+        secret: config.security.jwtSecret,
         signOptions: {
           expiresIn: '24h'
         }

--- a/src/modules/identity/auth/strategies/jwt.strategy.ts
+++ b/src/modules/identity/auth/strategies/jwt.strategy.ts
@@ -1,20 +1,20 @@
 import { ExtractJwt, Strategy } from 'passport-jwt'
 import { PassportStrategy } from '@nestjs/passport'
 import { ForbiddenException, Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import { UserService } from '@modules/identity/user/user.service'
 import { DecodedJwt } from '@modules/identity/types'
+import { AppConfigService } from '@modules/app-config/app-config.service'
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(
-    private readonly configService: ConfigService,
+    private readonly config: AppConfigService,
     private readonly userService: UserService
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: configService.get('JWT_SECRET')
+      secretOrKey: config.security.jwtSecret
     })
   }
 

--- a/src/modules/identity/auth/strategies/jwt.strategy.ts
+++ b/src/modules/identity/auth/strategies/jwt.strategy.ts
@@ -3,14 +3,11 @@ import { PassportStrategy } from '@nestjs/passport'
 import { ForbiddenException, Injectable } from '@nestjs/common'
 import { UserService } from '@modules/identity/user/user.service'
 import { DecodedJwt } from '@modules/identity/types'
-import { AppConfigService } from '@modules/app-config/app-config.service'
+import { AppConfig } from '@modules/app-config/app-config.service'
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(
-    private readonly config: AppConfigService,
-    private readonly userService: UserService
-  ) {
+  constructor(private readonly config: AppConfig, private readonly userService: UserService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,

--- a/test/identity.e2e-spec.ts
+++ b/test/identity.e2e-spec.ts
@@ -9,6 +9,7 @@ import { ConfigModule } from '@nestjs/config'
 import { hash } from 'bcrypt'
 import { User } from '@modules/identity/user/entities/user.entity'
 import { CreateUserDto } from '@modules/identity/user/dto/create-user.dto'
+import { AppConfigModule } from '@modules/app-config/app-config.module'
 
 describe('Identity Module (e2e)', () => {
   let app: INestApplication
@@ -20,6 +21,7 @@ describe('Identity Module (e2e)', () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
         IdentityModule,
+        AppConfigModule,
         ConfigModule.forRoot({
           isGlobal: true,
           ignoreEnvFile: true,


### PR DESCRIPTION
- feat: add app config module
- feat: add config values to new config service
- feat: switch old config usage to new typed config
- style: rename AppConfigService to simply AppConfig
- test: fix e2e by adding AppConfig import
- feat: improve config schema validation
